### PR TITLE
Add wildcards to makefile for sources

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,17 +3,6 @@ include guile.am
 moddir=$(prefix)/share/guile/site/2.0
 godir=$(libdir)/guile/2.0/ccache
 
-SOURCES = \
-	2d/agenda.scm\
-	2d/animation.scm\
-	2d/coroutine.scm\
-	2d/game-loop.scm\
-	2d/gl.scm\
-	2d/helpers.scm\
-	2d/math.scm\
-	2d/sprite.scm\
-	2d/texture.scm\
-	2d/vector.scm\
-	2d/window.scm
+SOURCES = $(wildcard 2d/*.scm  2d/*/*.scm)
 
 EXTRA_DIST += env.in


### PR DESCRIPTION
Makefile.am didn't change as modules were added
added wildcards so that all the files in 2d/ are used as sources

make completes just fine and 

```
cd examples
guile -L .. simple.scm
```

works but with a lot of warnings and errors during compliation
