### PR TITLE
Add (ice-9 format) module to imports for freeimage and ftgl

### DIFF
--- a/2d/wrappers/freeimage.scm
+++ b/2d/wrappers/freeimage.scm
@@ -23,7 +23,8 @@
 
 (define-module (2d wrappers freeimage)
   #:use-module (system foreign)
-  #:use-module (2d wrappers util))
+  #:use-module (2d wrappers util)
+  #:use-module (ice-9 format))
 
 (define libfreeimage (dynamic-link "libfreeimage"))
 

--- a/2d/wrappers/ftgl.scm
+++ b/2d/wrappers/ftgl.scm
@@ -23,7 +23,8 @@
 
 (define-module (2d wrappers ftgl)
   #:use-module (system foreign)
-  #:use-module (2d wrappers util))
+  #:use-module (2d wrappers util)
+  #:use-module (ice-9 format))
 
 (define libftgl (dynamic-link "libftgl"))
 


### PR DESCRIPTION
freeimage.scm and ftgl.scm were throwing warnings when running make
about a unsupported format option

GEN      2d/wrappers/freeimage.go
2d/wrappers/freeimage.scm:120:6: warning: "<freeimage-bitmap ~x width: ~d height: ~d bpp: ~d>": unsupported format option ~x, use (ice-9 format) instead
wrote `2d/wrappers/freeimage.go'
  GEN      2d/wrappers/ftgl.go
2d/wrappers/ftgl.scm:62:6: warning: "<ftgl-font ~x>": unsupported format option ~x, use (ice-9 format) instead
2d/wrappers/ftgl.scm:100:6: warning: "<ftgl-simple-layout ~x>": unsupported format option ~x, use (ice-9 format) instead
wrote`2d/wrappers/ftgl.go'
  GEN      2d/wrappers/gl.go
wrote `2d/wrappers/gl.go'

adding the modules to the module definition of each file fixes it
