### PR TITLE
Update simple example program

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,7 +24,8 @@
      (use-modules (figl gl)
                   (2d sprite)
                   (2d game-loop)
-                  (2d window))
+                  (2d window)
+                  (2d helpers))
 
      (define window-width 800)
      (define window-height 600)
@@ -38,13 +39,13 @@
                     #:position (vector (/ window-width 2)
                                        (/ window-height 2))))
 
-     (define (key-down key)
-       (display key) (newline)
-       (case key
-         ;; Quit program when ESCAPE or Q is pressed.
-         ((any-equal? key 'escape 'q)
-          (close-window)
-          (quit))))
+     (define (quit-demo)
+       (close-window)
+       (quit))
+
+     (define (key-down key mod unicode)
+       (cond ((any-equal? key 'escape 'q)
+              (quit-demo))))
 
      ;; Draw our sprite
      (define (render)
@@ -53,8 +54,9 @@
      ;; Register hooks. Lambdas are used as "trampolines" so that render
      ;; and key-down can be redefined later and the hooks will call the
      ;; updated procedures.
+     (add-hook! on-quit-hook (lambda () (quit-demo)))
      (add-hook! on-render-hook (lambda () (render)))
-     (add-hook! on-key-down-hook (lambda (key) (key-down key)))
+     (add-hook! on-key-down-hook (lambda (key mod unicode) (key-down key mod unicode)))
 
      ;; Start the game loop.
      ;; The render callback will be called through this procedure.


### PR DESCRIPTION
The example program provided in the readme doesn't work.
It seems that the on-key-down hook changed since the readme was written.
This takes bits from simple.scm to fix it.
